### PR TITLE
Development - Ticket 680 -  Display Customer Part Number

### DIFF
--- a/flsp-salesorder/__manifest__.py
+++ b/flsp-salesorder/__manifest__.py
@@ -33,5 +33,7 @@
         'views/flsp_customer_view.xml',
         'views/flsp_salesorder_view.xml',
         'views/flsp_saleorder_listview.xml',
+        'views/flsp_account_move_form.xml',
+        'views/flsp_stock_picking_form.xml',
     ],
 }

--- a/flsp-salesorder/models/__init__.py
+++ b/flsp-salesorder/models/__init__.py
@@ -2,3 +2,5 @@
 
 from . import customers
 from . import salesorder
+from . import account_move_line
+from . import stock_move

--- a/flsp-salesorder/models/account_move_line.py
+++ b/flsp-salesorder/models/account_move_line.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+
+from odoo import fields, models, api, _
+from odoo.exceptions import UserError
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+class flspaccountmoveline(models.Model):
+    _inherit = 'account.move.line'
+
+    flsp_customerscode = fields.Many2one('flspstock.customerscode', 'Customer Part Number')
+
+    def _copy_data_extend_business_fields(self, values):
+        # OVERRIDE to copy the 'sale_line_ids' field as well.
+        super(AccountMoveLine, self)._copy_data_extend_business_fields(values)
+        values['sale_line_ids'] = [(6, None, self.sale_line_ids.ids)]
+        values['flsp_customerscode'] = self.flsp_customerscode

--- a/flsp-salesorder/models/salesorder.py
+++ b/flsp-salesorder/models/salesorder.py
@@ -133,17 +133,12 @@ class flspsalesorderline(models.Model):
     _inherit = 'sale.order.line'
 
     flsp_customerscode = fields.Many2one('flspstock.customerscode', 'Customer Part Number')
-#    flsp_show_customercode = fields.Boolean(String="Show Customer Code at line", compute="_show_flsp_customercode_line")
+    flsp_prd_tmpl_id = fields.Many2one('product.template', String='Product template', compute='_compute_flsp_prd_tmpl_id')
 
-#    @api.depends('order_partner_id')
-#    def _show_flsp_customercode_line(self):
-#        customer_codes = self.env['flspstock.customerscode'].search([('partner_id', '=', self.order_partner_id.id)])
-#        show_field = False
-#        for part in customer_codes:
-#            show_field = True
-#        for record in self:
-#            record.flsp_show_customercode = show_field
-#        return show_field
+    @api.depends('product_id')
+    def _compute_flsp_prd_tmpl_id(self):
+        for rec in self:
+            rec.flsp_prd_tmpl_id = rec.product_id.product_tmpl_id
 
     @api.onchange('product_id')
     def flsp_product_id_onchange(self):

--- a/flsp-salesorder/models/stock_move.py
+++ b/flsp-salesorder/models/stock_move.py
@@ -13,13 +13,24 @@ class flspsostockmove(models.Model):
     def _compute_flsp_show_customercode(self):
         for each in self:
             if each.sale_line_id:
-                each.flsp_show_customercode = each.sale_line_id.order_id.flsp_show_customercode
+                if each.sale_line_id.order_id.flsp_show_customercode:
+                    each.flsp_show_customercode = each.sale_line_id.order_id.flsp_show_customercode
+                else:
+                    each.flsp_show_customercode = False
+            else:
+                each.flsp_show_customercode = False
 
 
     def _compute_flsp_customerscode(self):
         for each in self:
             if each.sale_line_id:
-                each.flsp_customerscode=each.sale_line_id.flsp_customerscode
+                if each.sale_line_id.flsp_customerscode:
+                    each.flsp_customerscode=each.sale_line_id.flsp_customerscode
+                else:
+                    each.flsp_customerscode = False
+            else:
+                each.flsp_customerscode = False
+
 
 
 class flspstockmoveline(models.Model):
@@ -30,10 +41,21 @@ class flspstockmoveline(models.Model):
 
     def _compute_flsp_customerscode(self):
         for each in self:
-            each.flsp_customerscode = each.move_id.flsp_customerscode
+            if each.move_id:
+                if each.move_id.flsp_customerscode:
+                    each.flsp_customerscode = each.move_id.flsp_customerscode
+                else:
+                    each.flsp_customerscode = False
+            else:
+                each.flsp_customerscode = False
 
 
     def _compute_flsp_show_customercode(self):
         for each in self:
             if each.move_id.sale_line_id:
-                each.flsp_show_customercode = each.move_id.sale_line_id.order_id.flsp_show_customercode
+                if each.move_id.sale_line_id.order_id.flsp_show_customercode:
+                    each.flsp_show_customercode = each.move_id.sale_line_id.order_id.flsp_show_customercode
+                else:
+                    each.flsp_show_customercode = True
+            else:
+                each.flsp_show_customercode = True

--- a/flsp-salesorder/models/stock_move.py
+++ b/flsp-salesorder/models/stock_move.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+
+from odoo import fields, models, api, _
+from odoo.exceptions import UserError
+
+
+class flspsostockmove(models.Model):
+    _inherit = 'stock.move'
+
+    flsp_customerscode = fields.Many2one('flspstock.customerscode', 'Customer Part Number', compute="_compute_flsp_customerscode")
+    flsp_show_customercode = fields.Boolean(String="Show Customer Code", compute="_compute_flsp_show_customercode")
+
+    def _compute_flsp_show_customercode(self):
+        for each in self:
+            if each.sale_line_id:
+                each.flsp_show_customercode = each.sale_line_id.order_id.flsp_show_customercode
+
+
+    def _compute_flsp_customerscode(self):
+        for each in self:
+            if each.sale_line_id:
+                each.flsp_customerscode=each.sale_line_id.flsp_customerscode
+
+
+class flspstockmoveline(models.Model):
+    _inherit = 'stock.move.line'
+
+    flsp_customerscode = fields.Many2one('flspstock.customerscode', 'Customer Part Number', compute="_compute_flsp_customerscode")
+    flsp_show_customercode = fields.Boolean(String="Show Customer Code", compute="_compute_flsp_show_customercode")
+
+    def _compute_flsp_customerscode(self):
+        for each in self:
+            each.flsp_customerscode = each.move_id.flsp_customerscode
+
+
+    def _compute_flsp_show_customercode(self):
+        for each in self:
+            if each.move_id.sale_line_id:
+                each.flsp_show_customercode = each.move_id.sale_line_id.order_id.flsp_show_customercode

--- a/flsp-salesorder/views/flsp_account_move_form.xml
+++ b/flsp-salesorder/views/flsp_account_move_form.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+ <odoo>
+        <!-- Add instructor field to existing view -->
+        <record model="ir.ui.view" id="flsp-saleorder_account_move_view">
+            <field name="name">flspsaleorder.account.move.form.inherit</field>
+            <field name="model">account.move</field>
+            <field name="priority">97</field>
+            <field name="inherit_id" ref="account.view_move_form"/>
+            <field name="arch" type="xml">
+              <xpath expr="//tree/field[@name='name']" position="after">
+                <field name="flsp_customerscode" />
+              </xpath>
+            </field>
+        </record>
+
+</odoo>

--- a/flsp-salesorder/views/flsp_salesorder_view.xml
+++ b/flsp-salesorder/views/flsp_salesorder_view.xml
@@ -22,7 +22,7 @@
                 <attribute name="attrs">{'readonly': True}</attribute>
               </xpath>
               <xpath expr="//tree/field[@name='name']" position="after">
-                <field name="flsp_customerscode" domain="[('partner_id', '=', parent.partner_id), ('product_id', '=', flsp_prd_tmpl_id)]" options="{'no_create': True, 'no_create_edit':True}" attrs="{'column_invisible': [('parent.flsp_show_customercode', '!=', True)], 'required': [('parent.flsp_show_customercode', '=', True)]}"/>
+                <field name="flsp_customerscode" domain="[('partner_id', '=', parent.partner_id), ('product_id', '=', flsp_prd_tmpl_id)]" options="{'no_create': True, 'no_create_edit':True}" attrs="{'column_invisible': [('parent.flsp_show_customercode', '!=', True)]}"/>
                 <field name="flsp_prd_tmpl_id" invisible="1"/>
               </xpath>
               <xpath expr="//field[@name='amount_total']" position="after">

--- a/flsp-salesorder/views/flsp_salesorder_view.xml
+++ b/flsp-salesorder/views/flsp_salesorder_view.xml
@@ -11,12 +11,18 @@
               <xpath expr="//field[@name='user_id']" position="attributes">
                 <attribute name="string">Outside Salesperson</attribute>
               </xpath>
+              <xpath expr="//field[@name='partner_id']" position="after">
+                <field name="flsp_show_customercode" invisible="1"/>
+              </xpath>
               <xpath expr="//field[@name='user_id']" position="after">
                 <field name="flsp_so_user_id"/>
                 <field name="flsp_so_dss_user_id"/>
               </xpath>
               <xpath expr="//tree/field[@name='price_unit']" position="attributes">
                 <attribute name="attrs">{'readonly': True}</attribute>
+              </xpath>
+              <xpath expr="//tree/field[@name='name']" position="after">
+                <field name="flsp_customerscode" domain="[('partner_id', '=', parent.partner_id)]" options="{'no_create': True, 'no_create_edit':True}" attrs="{'column_invisible': [('parent.flsp_show_customercode', '!=', True)], 'required': [('parent.flsp_show_customercode', '=', True)]}"/>
               </xpath>
               <xpath expr="//field[@name='amount_total']" position="after">
                 <field name="flsp_amount_deposit"/>

--- a/flsp-salesorder/views/flsp_salesorder_view.xml
+++ b/flsp-salesorder/views/flsp_salesorder_view.xml
@@ -22,7 +22,8 @@
                 <attribute name="attrs">{'readonly': True}</attribute>
               </xpath>
               <xpath expr="//tree/field[@name='name']" position="after">
-                <field name="flsp_customerscode" domain="[('partner_id', '=', parent.partner_id)]" options="{'no_create': True, 'no_create_edit':True}" attrs="{'column_invisible': [('parent.flsp_show_customercode', '!=', True)], 'required': [('parent.flsp_show_customercode', '=', True)]}"/>
+                <field name="flsp_customerscode" domain="[('partner_id', '=', parent.partner_id), ('product_id', '=', flsp_prd_tmpl_id)]" options="{'no_create': True, 'no_create_edit':True}" attrs="{'column_invisible': [('parent.flsp_show_customercode', '!=', True)], 'required': [('parent.flsp_show_customercode', '=', True)]}"/>
+                <field name="flsp_prd_tmpl_id" invisible="1"/>
               </xpath>
               <xpath expr="//field[@name='amount_total']" position="after">
                 <field name="flsp_amount_deposit"/>

--- a/flsp-salesorder/views/flsp_stock_picking_form.xml
+++ b/flsp-salesorder/views/flsp_stock_picking_form.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+ <odoo>
+        <record model="ir.ui.view" id="flsp-salesorder_stock_picking_form">
+            <field name="name">flspsalesorder.stock.picking.form.inherit</field>
+            <field name="model">stock.picking</field>
+            <field name="priority">94</field>
+            <field name="inherit_id" ref="stock.view_picking_form"/>
+            <field name="arch" type="xml">
+              <xpath expr="//tree/field[@name='product_id']" position="after">
+                <field name="flsp_customerscode" attrs="{'invisible': [('flsp_show_customercode', '!=', True)]}" optional="hide"/>
+                <field name="flsp_show_customercode" invisible="1"/>
+              </xpath>
+              <xpath expr="//form[1]/sheet[1]/notebook[1]/page[3]/field[@name='move_ids_without_package']/tree[1]/field[@name='product_id']" position="after">
+                <field name="flsp_customerscode" attrs="{'invisible': [('flsp_show_customercode', '!=', True)]}" optional="hide"/>
+                <field name="flsp_show_customercode" invisible="1"/>
+              </xpath>
+            </field>
+        </record>
+ </odoo>

--- a/flsp_customer_badge/report/flsp_customer_badge_commercial_invoice.xml
+++ b/flsp_customer_badge/report/flsp_customer_badge_commercial_invoice.xml
@@ -204,11 +204,9 @@
                                 </t>
                                 <t t-set="product_code" t-value="line.product_id.default_code"/>
                                 <t t-set="product_desc" t-value="line.product_id.name"/>
-                                <t t-foreach="line.product_id.customerscode_ids" t-as="customercode_id">
-                                    <t t-if="customercode_id.partner_id == o.partner_id">
-                                        <t t-set="product_code" t-value="customercode_id.part_number"/>
-                                        <t t-set="product_desc" t-value="customercode_id.description"/>
-                                    </t>
+                                <t t-if="line.flsp_customerscode">
+                                    <t t-set="product_code" t-value="line.flsp_customerscode.part_number"/>
+                                    <t t-set="product_desc" t-value="line.flsp_customerscode.description"/>
                                 </t>
 
                                 <t t-set="current_subtotal" t-value="current_subtotal + line.price_subtotal" groups="account.group_show_line_subtotals_tax_excluded"/>

--- a/flsp_customer_badge/report/flsp_customer_badge_commercial_invoice.xml
+++ b/flsp_customer_badge/report/flsp_customer_badge_commercial_invoice.xml
@@ -208,6 +208,14 @@
                                     <t t-set="product_code" t-value="line.flsp_customerscode.part_number"/>
                                     <t t-set="product_desc" t-value="line.flsp_customerscode.description"/>
                                 </t>
+				<t t-else="">
+				    <t t-foreach="line.product_id.customerscode_ids" t-as="customercode_id">
+					<t t-if="customercode_id.partner_id == o.partner_id">
+					    <t t-set="product_code" t-value="customercode_id.part_number"/>
+                                    	    <t t-set="product_desc" t-value="customercode_id.description"/>
+					</t>
+				    </t>
+				</t>
 
                                 <t t-set="current_subtotal" t-value="current_subtotal + line.price_subtotal" groups="account.group_show_line_subtotals_tax_excluded"/>
                                 <t t-set="current_subtotal" t-value="current_subtotal + line.price_total" groups="account.group_show_line_subtotals_tax_included"/>

--- a/flsp_customer_badge/report/flsp_customer_badge_invoice_report.xml
+++ b/flsp_customer_badge/report/flsp_customer_badge_invoice_report.xml
@@ -216,6 +216,14 @@
                                         <t t-set="product_code" t-value="line.flsp_customerscode.part_number"/>
                                         <t t-set="product_desc" t-value="line.flsp_customerscode.description"/>
                                     </t>
+				    <t t-else="">
+				        <t t-foreach="line.product_id.customerscode_ids" t-as="customercode_id">
+					    <t t-if="customercode_id.partner_id == o.partner_id">
+					        <t t-set="product_code" t-value="customercode_id.part_number"/>
+                                    	        <t t-set="product_desc" t-value="customercode_id.description"/>
+					    </t>
+				        </t>
+				    </t>
                                     <t t-if="o.flsp_sale_discount+o.flsp_freight_discount>0">
                                         <t t-set="current_subtotal" t-value="current_subtotal + line.price_subtotal+(line.quantity*line.price_unit*line.discount/100)" groups="account.group_show_line_subtotals_tax_excluded"/>
                                         <t t-set="current_subtotal" t-value="current_subtotal + line.price_total+(line.quantity*line.price_unit*line.discount/100)" groups="account.group_show_line_subtotals_tax_included"/>

--- a/flsp_customer_badge/report/flsp_customer_badge_invoice_report.xml
+++ b/flsp_customer_badge/report/flsp_customer_badge_invoice_report.xml
@@ -212,11 +212,9 @@
                                 <t t-foreach="lines" t-as="line">
                                     <t t-set="product_code" t-value="line.product_id.default_code"/>
                                     <t t-set="product_desc" t-value="line.name"/>
-                                    <t t-foreach="line.product_id.customerscode_ids" t-as="customercode_id">
-                                        <t t-if="customercode_id.partner_id == o.partner_id">
-                                            <t t-set="product_code" t-value="customercode_id.part_number"/>
-                                            <t t-set="product_desc" t-value="customercode_id.description"/>
-                                        </t>
+                                    <t t-if="line.flsp_customerscode">
+                                        <t t-set="product_code" t-value="line.flsp_customerscode.part_number"/>
+                                        <t t-set="product_desc" t-value="line.flsp_customerscode.description"/>
                                     </t>
                                     <t t-if="o.flsp_sale_discount+o.flsp_freight_discount>0">
                                         <t t-set="current_subtotal" t-value="current_subtotal + line.price_subtotal+(line.quantity*line.price_unit*line.discount/100)" groups="account.group_show_line_subtotals_tax_excluded"/>

--- a/flsp_customer_badge/report/flsp_customer_badge_packing_slip.xml
+++ b/flsp_customer_badge/report/flsp_customer_badge_packing_slip.xml
@@ -134,12 +134,18 @@
                                         <t t-if="move_line.product_id.id != current_product">
                                             <t t-set="product_code" t-value="move_line.product_id.default_code"/>
                                             <t t-set="product_desc" t-value="move_line.product_id.name"/>
-                                            <t t-foreach="move_line.flsp_customerscode" t-as="customercode_id">
-                                                <t t-if="customercode_id.partner_id == o.partner_id.parent_id">
-                                                    <t t-set="product_code" t-value="customercode_id.part_number"/>
-                                                    <t t-set="product_desc" t-value="customercode_id.description"/>
-                                                </t>
+                                            <t t-if="move_line.flsp_customerscode">
+                                                <t t-set="product_code" t-value="move_line.flsp_customerscode.part_number"/>
+                                                <t t-set="product_desc" t-value="move_line.flsp_customerscode.description"/>
                                             </t>
+					    <t t-else="">
+				                <t t-foreach="move_line.product_id.customerscode_ids" t-as="customercode_id">
+					            <t t-if="customercode_id.partner_id == o.sale_id.partner_id">
+					                <t t-set="product_code" t-value="customercode_id.part_number"/>
+                                    	                <t t-set="product_desc" t-value="customercode_id.description"/>
+					            </t>
+				                </t>
+				            </t>
 
                                             <t t-foreach="move_line.product_id.packaging_ids" t-as="packaging_id">
                                                 <t t-set="current_product" t-value="move_line.product_id.id"/>
@@ -220,12 +226,18 @@
                                 <t t-foreach="o.move_line_ids.sorted(key=lambda r: r.flsp_lot_name)" t-as="move_line">
                                     <t t-set="product_code" t-value="move_line.product_id.default_code"/>
                                     <t t-set="product_desc" t-value="move_line.product_id.name"/>
-                                    <t t-foreach="move_line.flsp_customerscode" t-as="customercode_id">
-                                        <t t-if="customercode_id.partner_id == o.partner_id.parent_id">
-                                            <t t-set="product_code" t-value="customercode_id.part_number"/>
-                                            <t t-set="product_desc" t-value="customercode_id.description"/>
-                                        </t>
+                                    <t t-if="move_line.flsp_customerscode">
+                                        <t t-set="product_code" t-value="move_line.flsp_customerscode.part_number"/>
+                                        <t t-set="product_desc" t-value="move_line.flsp_customerscode.description"/>
                                     </t>
+				    <t t-else="">
+				        <t t-foreach="move_line.product_id.customerscode_ids" t-as="customercode_id">
+					    <t t-if="customercode_id.partner_id == o.sale_id.partner_id">
+					        <t t-set="product_code" t-value="customercode_id.part_number"/>
+                                    	        <t t-set="product_desc" t-value="customercode_id.description"/>
+					    </t>
+				        </t>
+				    </t>
 
                                     <tr>
                                         <td style="border: 2px solid #001f54; font-family: Franklin Gothic Medium; font-size: 14px; font-style: normal; font-weight: lighter; color: #000000; text-align: center; padding-top: 4px; padding-bottom: 4px; padding-left: 4px; padding-right: 4px; vertical-align: top; word-wrap: normal; white-space:nowrap; ">

--- a/flsp_customer_badge/report/flsp_customer_badge_packing_slip.xml
+++ b/flsp_customer_badge/report/flsp_customer_badge_packing_slip.xml
@@ -134,8 +134,8 @@
                                         <t t-if="move_line.product_id.id != current_product">
                                             <t t-set="product_code" t-value="move_line.product_id.default_code"/>
                                             <t t-set="product_desc" t-value="move_line.product_id.name"/>
-                                            <t t-foreach="move_line.product_id.customerscode_ids" t-as="customercode_id">
-                                                <t t-if="customercode_id.partner_id == o.partner_id">
+                                            <t t-foreach="move_line.flsp_customerscode" t-as="customercode_id">
+                                                <t t-if="customercode_id.partner_id == o.partner_id.parent_id">
                                                     <t t-set="product_code" t-value="customercode_id.part_number"/>
                                                     <t t-set="product_desc" t-value="customercode_id.description"/>
                                                 </t>
@@ -220,8 +220,8 @@
                                 <t t-foreach="o.move_line_ids.sorted(key=lambda r: r.flsp_lot_name)" t-as="move_line">
                                     <t t-set="product_code" t-value="move_line.product_id.default_code"/>
                                     <t t-set="product_desc" t-value="move_line.product_id.name"/>
-                                    <t t-foreach="move_line.product_id.customerscode_ids" t-as="customercode_id">
-                                        <t t-if="customercode_id.partner_id == o.partner_id">
+                                    <t t-foreach="move_line.flsp_customerscode" t-as="customercode_id">
+                                        <t t-if="customercode_id.partner_id == o.partner_id.parent_id">
                                             <t t-set="product_code" t-value="customercode_id.part_number"/>
                                             <t t-set="product_desc" t-value="customercode_id.description"/>
                                         </t>

--- a/flsp_customer_badge/report/flsp_customer_badge_sales_report.xml
+++ b/flsp_customer_badge/report/flsp_customer_badge_sales_report.xml
@@ -198,11 +198,9 @@
                         <t t-foreach="doc.order_line" t-as="line">
                             <t t-set="product_code" t-value="line.product_id.default_code"/>
                             <t t-set="product_desc" t-value="line.product_id.name"/>
-                            <t t-foreach="line.product_id.customerscode_ids" t-as="customercode_id">
-                                <t t-if="customercode_id.partner_id == doc.partner_id">
-                                    <t t-set="product_code" t-value="customercode_id.part_number"/>
-                                    <t t-set="product_desc" t-value="customercode_id.description"/>
-                                </t>
+                            <t t-if="line.flsp_customerscode">
+                                <t t-set="product_code" t-value="line.flsp_customerscode.part_number"/>
+                                <t t-set="product_desc" t-value="line.flsp_customerscode.description"/>
                             </t>
 
                             <t t-set="current_subtotal" t-value="current_subtotal + line.price_subtotal" groups="account.group_show_line_subtotals_tax_excluded"/>

--- a/flsp_customer_badge/report/flsp_customer_badge_sales_report.xml
+++ b/flsp_customer_badge/report/flsp_customer_badge_sales_report.xml
@@ -202,6 +202,14 @@
                                 <t t-set="product_code" t-value="line.flsp_customerscode.part_number"/>
                                 <t t-set="product_desc" t-value="line.flsp_customerscode.description"/>
                             </t>
+			    <t t-else="">
+				<t t-foreach="line.product_id.customerscode_ids" t-as="customercode_id">
+				    <t t-if="customercode_id.partner_id == o.partner_id">
+					<t t-set="product_code" t-value="customercode_id.part_number"/>
+                                    	<t t-set="product_desc" t-value="customercode_id.description"/>
+				    </t>
+				</t>
+			    </t>
 
                             <t t-set="current_subtotal" t-value="current_subtotal + line.price_subtotal" groups="account.group_show_line_subtotals_tax_excluded"/>
                             <t t-set="current_subtotal" t-value="current_subtotal + line.price_total" groups="account.group_show_line_subtotals_tax_included"/>

--- a/flspstock/models/flsp_customer_part_code.py
+++ b/flspstock/models/flsp_customer_part_code.py
@@ -5,6 +5,7 @@ class Customerscode(models.Model):
     _name = 'flspstock.customerscode'
     _description = "Customer Part Number"
     _check_company_auto = True
+    _rec_name = "part_number"
 
     sequence = fields.Integer('Sequence', default=1, help="The first in the sequence is the default one.")
     product_id = fields.Many2one('product.template', string='Product', check_company=True)


### PR DESCRIPTION
Changes to be performed: 
- Sales Order form 
- Included a column for customer part number. 
- Sales/Quotation Order Report. 
- Invoice. 
- Commercial Invoice 
- Packing List. 

Forms/tables changed: 
- Sales Order Line (optional field, to show only if the customer has a part number saved in the product) 
- Account Move (Invoice, to always show the field. Read-only) 
- Stock Move and Stock Move Line (For traceability. User must be able to hide the field. Hide it by default. Read-only)
